### PR TITLE
Export patched Fab component

### DIFF
--- a/packages/gatsby-theme-material-ui/src/components/index.js
+++ b/packages/gatsby-theme-material-ui/src/components/index.js
@@ -3,3 +3,4 @@ export { default as GatsbyLink } from "./gatsby-link";
 export { default as CardActionArea } from "./card-action-area";
 export { default as Button } from "./button";
 export { default as IconButton } from "./icon-button";
+export { default as Fab } from "./fab";


### PR DESCRIPTION
The documentation suggests that a `Fab` component can be imported, however it isn't being exported by the package. This change makes `Fab` available for use!