### PR TITLE
Fix broken import when minimizing bundle size

### DIFF
--- a/packages/gatsby-theme-material-ui-top-layout/src/theme.js
+++ b/packages/gatsby-theme-material-ui-top-layout/src/theme.js
@@ -1,4 +1,4 @@
-import { createMuiTheme } from "@material-ui/core";
+import { createMuiTheme } from "@material-ui/core/styles";
 
 const theme = createMuiTheme();
 


### PR DESCRIPTION
I'm using `gatsby-theme-material-ui` in my project and ran into an issue when trying to use `babel-plugin-transform-imports` as outlined here for [minimizing MUI bundle size](https://material-ui.com/guides/minimizing-bundle-size/). Specifically, this:

```
Can't resolve '@material-ui/core/esm/createMuiTheme' in 'myproject/node_modules/gatsby-theme-material-ui-top-layout/src'
```

The docs note this issue:

> This is because `@material-ui/styles` is re-exported through core, but the full import is not allowed. You have an import like this in your code:
> ```js
> import {makeStyles, createStyles} from '@material-ui/core';
> ```
> The fix is simple, define the import separately:
> ```js
> import {makeStyles, createStyles} from '@material-ui/core/styles';
> ```
> Enjoy significantly faster start times.

I was a bit surprised because I wasn't expecting my babel plugins to be applied to my dependencies. That's when I noticed this line in this project:

https://github.com/hupe1980/gatsby-theme-material-ui/blob/3f119a1215956c5240d0585a62779354d696b702/packages/gatsby-theme-material-ui/gatsby-config.js#L43-L44

I think the "real" solution to this issue is to do as that comment says and transpile these packages before publishing to npm. But, for now, just to fix my issue, just changing the import will work.

This should have no impact on users currently using the theme as it is still importing the same thing, just from a different place.