### PR TITLE
Increase threshold on stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 30
+daysUntilStale: 180
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: 30
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned


### PR DESCRIPTION
From my experience on Material-UI, this bot is more harmful than helping. Important problems can usually stay open for months without any activity, only people upvoting the issues. This project has a low issue stream volume. I think that a human can close the issues if required, no need for a bot.