### PR TITLE
Two small improvements to the README

### DIFF
--- a/packages/gatsby-theme-material-ui/README.md
+++ b/packages/gatsby-theme-material-ui/README.md
@@ -104,6 +104,8 @@ module.exports = {
 
 For more options, have a look at the plugin [readme](https://github.com/hupe1980/gatsby-plugin-webfonts/blob/master/gatsby-plugin-webfonts/README.md).
 
+> Note: If the changes you made in `src/gatsby-theme-material-ui-top-layout/theme.js` are not showing up, you might want to run `gatsby clean` to clean up the .cache folder and try again. This is required for newly shadowed files.
+
 ## Theming
 
 Create & Edit src/gatsby-theme-material-ui-top-layout/theme.js

--- a/packages/gatsby-theme-material-ui/README.md
+++ b/packages/gatsby-theme-material-ui/README.md
@@ -27,6 +27,26 @@ module.exports = {
 };
 ```
 
+## Testing your installation
+
+Replace the contents in your `pages/index.js` with the following
+```javascript
+import React from "react";
+import { Button, Box } from "@mui/material";
+
+const IndexPage = () => {
+  return (
+    <Box p={4}>
+      <Button variant="contained">Hello gatsby-theme-material-ui</Button>
+    </Box>
+  );
+};
+
+export default IndexPage;
+```
+
+You should be greeted with a MUI button when you navigate to the root of your site.
+
 ### top-layout
 
 You'll see several references below to the ["top-layout" theme](https://github.com/hupe1980/gatsby-theme-material-ui/tree/master/packages/gatsby-theme-material-ui-top-layout). Its role is to [prevent the Flash Of Unstyle Content](https://github.com/hupe1980/gatsby-theme-material-ui/pull/8).


### PR DESCRIPTION
Added two things in the README for gatsby-theme-material-ui:

1) Added a "testing your installation' section with a small mui example so people can quickly verify everything is working as expected
2) I ran into the problem where the changes i made  in `src/gatsby-theme-material-ui-top-layout/theme.js` were not showing up. I figured out I needed to run gatsby clean after shadowing changes. Added the tip in the readme.

Feel free to merge or discard this pull request.