### PR TITLE
Add ButtonBase support

### DIFF
--- a/packages/gatsby-material-ui-components/src/button-base.tsx
+++ b/packages/gatsby-material-ui-components/src/button-base.tsx
@@ -1,0 +1,8 @@
+import MuiButtonBase, { ButtonBaseProps } from '@mui/material/ButtonBase';
+
+import patchButtonBaseComponent from './patch-base-button-components';
+
+export const ButtonBase = patchButtonBaseComponent<
+  HTMLButtonElement,
+  ButtonBaseProps
+>(MuiButtonBase);


### PR DESCRIPTION
I have difficulty when using customized `Button` component from this repo. Especially when I tried to "materialize" company logo on Gatsby. Instead, why don't we add ButtonBase support? It makes customization a lot easier.